### PR TITLE
chore(runner): use QElapsedTimer instead of QTime

### DIFF
--- a/include/Runner.hpp
+++ b/include/Runner.hpp
@@ -21,8 +21,10 @@
 #include <Core.hpp>
 #include <IO.hpp>
 #include <QCodeEditor>
+#include <QElapsedTimer>
 #include <QObject>
 #include <QProcess>
+
 namespace Core
 {
 class Runner : public QObject, private Base::Files
@@ -71,7 +73,7 @@ class Runner : public QObject, private Base::Files
     QProcess *detachedHandle = nullptr;
     MessageLogger *log;
     QVector<QProcess *> runner = QVector<QProcess *>(3, nullptr);
-    QVector<QTime *> timers = QVector<QTime *>(3, nullptr);
+    QVector<QElapsedTimer *> timers = QVector<QElapsedTimer *>(3, nullptr);
 };
 
 } // namespace Core

--- a/src/Runner.cpp
+++ b/src/Runner.cpp
@@ -261,7 +261,7 @@ void Runner::compilationFinished(bool success)
             if (isRun[i])
             {
                 runner[i] = new QProcess();
-                timers[i] = new QTime();
+                timers[i] = new QElapsedTimer();
 
                 QTimer *killtimer = new QTimer(runner[i]);
                 killtimer->setSingleShot(true);


### PR DESCRIPTION
I got this from building:

D:\GitHub\cp-editor\src\Runner.cpp(311): warning C4996: 'QTime::start':
Use QElapsedTimer instead [D:\GitHub\cp-editor\build\CPEditor.vcxproj]

D:\GitHub\cp-editor\src\Runner.cpp(337): warning C4996: 'QTime::elapsed':
Use QElapsedTimer instead [D:\GitHub\cp-editor\build\CPEditor.vcxproj]

Maybe QElapsedTimer is a better choice.