### PR TITLE
Formatter changes

### DIFF
--- a/src/Formatter.cpp
+++ b/src/Formatter.cpp
@@ -96,7 +96,7 @@ void Formatter::format(QCodeEditor *editor)
         }
 
         file->open(QIODevice::ReadWrite | QFile::Text);
-        editor->setPlainText(file->readAll());
+        editor->setPlainText(formatProcess.readAllStandardOutput());
         editor->setTextCursor(old_pos);
         log->info("Formatter", "Formatting completed");
     }

--- a/src/Formatter.cpp
+++ b/src/Formatter.cpp
@@ -96,7 +96,10 @@ void Formatter::format(QCodeEditor *editor)
         }
 
         file->open(QIODevice::ReadWrite | QFile::Text);
-        editor->setPlainText(formatProcess.readAllStandardOutput());
+        auto doc = editor->document();
+        QTextCursor cursor(doc);
+        cursor.select(QTextCursor::Document);
+        cursor.insertText(formatProcess.readAllStandardOutput());
         editor->setTextCursor(old_pos);
         log->info("Formatter", "Formatting completed");
     }

--- a/src/SettingsManager.cpp
+++ b/src/SettingsManager.cpp
@@ -103,7 +103,7 @@ QString SettingManager::getCompileCommandJava()
 }
 QString SettingManager::getFormatCommand()
 {
-    return mSettings->value("format", "clang-format -i").toString();
+    return mSettings->value("format", "clang-format").toString();
 }
 QString SettingManager::getRuntimeArgumentsCpp()
 {

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -450,6 +450,9 @@ void AppWindow::onSettingsApplied()
         settingManager->setSystemThemeDark(false);
     }
 
+    if (settingManager->getFormatCommand().contains(QRegularExpression(" -i(?: |$)")))
+        QMessageBox::warning(this, "Formatter", "Please don't use -i in the format command.");
+
     updater->setBeta(settingManager->isBeta());
     maybeSetHotkeys();
 

--- a/src/preferencewindow.cpp
+++ b/src/preferencewindow.cpp
@@ -187,7 +187,7 @@ void PreferenceWindow::resetSettings()
     manager->setRuntimeArgumentsJava("");
     manager->setRuntimeArgumentsPython("");
 
-    manager->setFormatCommand("clang-format -i");
+    manager->setFormatCommand("clang-format");
 
     manager->setCompileCommandsJava("javac");
     manager->setCompileCommandsCpp("g++ -Wall");


### PR DESCRIPTION
Don't know why, but use the output instead of `-i` fixes #80.

~~Please remind the users to change the format command. Or is it better to let the user choose clang-format binary and style instead of the whole command?~~ See f5efec8.

This PR also changes the way of applying the formatting to the editor, so that format won't clear undo history.