### PR TITLE
refactor: use QSettings::clear() for reset settings

### DIFF
--- a/include/SettingsManager.hpp
+++ b/include/SettingsManager.hpp
@@ -199,6 +199,8 @@ class SettingManager
     void removeSnippet(QString lang, QString name);
     QStringList getSnippetsNames(QString lang);
 
+    void resetSettings();
+
   private:
     QString mSettingsFile;
     QSettings *mSettings;

--- a/include/preferencewindow.hpp
+++ b/include/preferencewindow.hpp
@@ -20,7 +20,6 @@ class PreferenceWindow : public QMainWindow
 
   public:
     explicit PreferenceWindow(Settings::SettingManager *manager, QWidget *parent = nullptr);
-    void resetSettings();
     void updateShow();
     ~PreferenceWindow();
 

--- a/src/SettingsManager.cpp
+++ b/src/SettingsManager.cpp
@@ -476,4 +476,9 @@ SettingsData SettingManager::toData()
     return data;
 }
 
+void SettingManager::resetSettings()
+{
+    mSettings->clear();
+}
+
 } // namespace Settings

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -360,7 +360,7 @@ void AppWindow::on_actionRestore_Settings_triggered()
                                      QMessageBox::Yes | QMessageBox::No);
     if (res == QMessageBox::Yes)
     {
-        preferenceWindow->resetSettings();
+        settingManager->resetSettings();
         onSettingsApplied();
     }
 }

--- a/src/preferencewindow.cpp
+++ b/src/preferencewindow.cpp
@@ -168,57 +168,6 @@ void PreferenceWindow::extractSettingsFromUi()
     manager->setHotkeySnippets(ui->snippets_hotkey->keySequence());
 }
 
-void PreferenceWindow::resetSettings()
-{
-    QFont defaultFont;
-    currentFont = defaultFont;
-
-    manager->setConnectionPort(10045);
-    manager->setTabStop(4);
-    manager->setGeometry(QRect{});
-    manager->setFont("");
-    manager->setDefaultLanguage("Cpp");
-
-    manager->setTemplatePathCpp("");
-    manager->setTemplatePathJava("");
-    manager->setTemplatePathPython("");
-
-    manager->setRuntimeArgumentsCpp("");
-    manager->setRuntimeArgumentsJava("");
-    manager->setRuntimeArgumentsPython("");
-
-    manager->setFormatCommand("clang-format -i");
-
-    manager->setCompileCommandsJava("javac");
-    manager->setCompileCommandsCpp("g++ -Wall");
-
-    manager->setRunCommandJava("java");
-    manager->setRunCommandPython("python");
-
-    manager->setEditorTheme("Light");
-
-    manager->setSystemThemeDark(false);
-    manager->setHotKeyInUse(false);
-    manager->setAutoParenthesis(true);
-    manager->setAutoIndent(true);
-    manager->setAutoSave(false);
-    manager->setWrapText(false);
-    manager->setBeta(false);
-    manager->setTabs(false);
-    manager->setSaveTests(false);
-    manager->setCompetitiveCompanionActive(false);
-    manager->setMaximizedWindow(false);
-    manager->checkUpdateOnStartup(true);
-
-    manager->setHotkeyRun(QKeySequence());
-    manager->setHotkeyKill(QKeySequence());
-    manager->setHotkeyCompile(QKeySequence());
-    manager->setHotkeyCompileRun(QKeySequence());
-    manager->setHotkeyFormat(QKeySequence());
-    manager->setHotkeyViewModeToggler(QKeySequence());
-    manager->setHotkeySnippets(QKeySequence());
-}
-
 void PreferenceWindow::updateShow()
 {
     applySettingsToui();


### PR DESCRIPTION
Sinces all defaults are in the "get" functions, a simple clear()
should do the resetting well.

What's more, this fixes the bug that unused settings won't be cleared.

For example, there is still "compile" without "cpp" in my ini file.