### PR TITLE
refactor: tabs -> tabsReplaced

### DIFF
--- a/include/SettingsManager.hpp
+++ b/include/SettingsManager.hpp
@@ -69,7 +69,7 @@ struct SettingsData
     bool isAutoSave;
     bool isWrapText;
     bool isBeta;
-    bool isTabsBeingUsed;
+    bool isTabsReplaced;
     bool shouldSaveTests;
     bool isCompanionActive;
     bool isWindowMaximized;
@@ -158,8 +158,8 @@ class SettingManager
     bool isBeta();
     void setBeta(bool value);
 
-    bool isTabs();
-    void setTabs(bool value);
+    bool isTabsReplaced();
+    void setTabsReplaced(bool value);
 
     bool isSaveTests();
     void setSaveTests(bool value);

--- a/src/SettingsManager.cpp
+++ b/src/SettingsManager.cpp
@@ -56,9 +56,9 @@ bool SettingManager::isBeta()
     return mSettings->value("beta", "false").toBool();
 }
 
-bool SettingManager::isTabs()
+bool SettingManager::isTabsReplaced()
 {
-    return mSettings->value("use_tabs", "false").toBool();
+    return mSettings->value("replace_tabs", "false").toBool();
 }
 
 bool SettingManager::isSaveTests()
@@ -206,12 +206,12 @@ void SettingManager::setBeta(bool value)
         mSettings->setValue("beta", QString::fromStdString("false"));
 }
 
-void SettingManager::setTabs(bool value)
+void SettingManager::setTabsReplaced(bool value)
 {
     if (value)
-        mSettings->setValue("use_tabs", QString::fromStdString("true"));
+        mSettings->setValue("replace_tabs", QString::fromStdString("true"));
     else
-        mSettings->setValue("use_tabs", QString::fromStdString("false"));
+        mSettings->setValue("replace_tabs", QString::fromStdString("false"));
 }
 
 void SettingManager::setSaveTests(bool value)
@@ -459,7 +459,7 @@ SettingsData SettingManager::toData()
     data.isAutoSave = isAutoSave();
     data.isWrapText = isWrapText();
     data.isBeta = isBeta();
-    data.isTabsBeingUsed = isTabs();
+    data.isTabsReplaced = isTabsReplaced();
     data.shouldSaveTests = isSaveTests();
     data.isCompanionActive = isCompetitiveCompanionActive();
     data.isWindowMaximized = isMaximizedWindow();

--- a/src/mainwindow.cc
+++ b/src/mainwindow.cc
@@ -297,13 +297,12 @@ void MainWindow::setCFToolsUI()
                 cftools->submit(companionData.url, language);
             }
         });
-
     }
     if (!Network::CFTools::check())
     {
         submitToCodeforces->setEnabled(false);
-        log.error("CFTools",
-                  "You will not be able to submit code to codeforces because CFTools is not installed or is not on SYSTEM PATH");
+        log.error("CFTools", "You will not be able to submit code to codeforces because CFTools is not installed or is "
+                             "not on SYSTEM PATH");
     }
 }
 
@@ -383,7 +382,7 @@ void MainWindow::setSettingsData(Settings::SettingsData data, bool shouldPerform
     this->data = data;
     formatter->updateCommand(data.formatCommand);
 
-    editor->setTabReplace(data.isTabsBeingUsed);
+    editor->setTabReplace(data.isTabsReplaced);
     editor->setTabReplaceSize(data.tabStop);
     editor->setAutoIndentation(data.isAutoIndent);
     editor->setAutoParentheses(data.isAutoParenthesis);

--- a/src/preferencewindow.cpp
+++ b/src/preferencewindow.cpp
@@ -74,7 +74,7 @@ void PreferenceWindow::applySettingsToui()
     ui->wrap->setChecked(manager->isWrapText());
     ui->indent->setChecked(manager->isAutoIndent());
     ui->parentheses->setChecked(manager->isAutoParenthesis());
-    ui->tabs->setChecked(manager->isTabs());
+    ui->replace_tabs->setChecked(manager->isTabsReplaced());
 
     ui->defaultLang->setCurrentText(manager->getDefaultLang());
     ui->format_cmd->setText(manager->getFormatCommand());
@@ -132,7 +132,7 @@ void PreferenceWindow::extractSettingsFromUi()
     manager->setWrapText(ui->wrap->isChecked());
     manager->setAutoIndent(ui->indent->isChecked());
     manager->setAutoParenthesis(ui->parentheses->isChecked());
-    manager->setTabs(ui->tabs->isChecked());
+    manager->setTabsReplaced(ui->replace_tabs->isChecked());
 
     manager->setDefaultLanguage(ui->defaultLang->currentText());
     manager->setFormatCommand(ui->format_cmd->text());
@@ -204,7 +204,7 @@ void PreferenceWindow::resetSettings()
     manager->setAutoSave(false);
     manager->setWrapText(false);
     manager->setBeta(false);
-    manager->setTabs(false);
+    manager->setTabsReplaced(false);
     manager->setSaveTests(false);
     manager->setCompetitiveCompanionActive(false);
     manager->setMaximizedWindow(false);
@@ -422,7 +422,7 @@ void PreferenceWindow::applySettingsToEditor()
 {
     auto data = manager->toData();
 
-    editor->setTabReplace(data.isTabsBeingUsed);
+    editor->setTabReplace(data.isTabsReplaced);
     editor->setTabReplaceSize(data.tabStop);
     editor->setAutoIndentation(data.isAutoIndent);
     editor->setAutoParentheses(data.isAutoParenthesis);

--- a/ui/preferencewindow.ui
+++ b/ui/preferencewindow.ui
@@ -194,7 +194,7 @@
                  </widget>
                 </item>
                 <item row="6" column="0">
-                 <widget class="QCheckBox" name="tabs">
+                 <widget class="QCheckBox" name="replace_tabs">
                   <property name="text">
                    <string>Always replace tabs with spaces</string>
                   </property>


### PR DESCRIPTION
It was really confusing: `editor->setTabReplace(data.isTabsBeingUsed);`