### PR TITLE
feat(formatter): clang-format update

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - Parse problem example test cases from over 30+ online platforms, and test on them with verdict feedback.
 - You can use code snippets conveniently.
 - Fast and memory efficient. Runs flawlessly on low-end devices.
-- Code formating using tools like clang-format.
+- Code formating using clang-format.
 - Customizable hotkeys for actions in the editor. 
 - Over 5 themes to choose from (Drakula, Monkai, Solarised, Solarised Dark and Light).
 - Supports Multi tabs.
@@ -48,12 +48,12 @@ You **must not** make your Java class public, and the name of the class should b
 
 | Shortcut     | Description                                                  |
 | ------------ | ------------------------------------------------------------ |
-| CTRL+N       | Launches a new Session and resets the editor. Once you solved a problem you need to Launch a new Session for the next Problem. |
-| CTRL+Q       | Quit and Exit Application                                    |
-| CTRL+O       | Opens a new Source File into Editor                          |
+| CTRL+N       | Launches a new session and resets the editor. Once you solved a problem you need to launch a new session for the next problem. |
+| CTRL+Q       | Quit and exit application                                    |
+| CTRL+O       | Opens a new source file into the editor                      |
 | CTRL+S       | Saves the current content of editor to a File                |
 | CTRL+Shift+S | Saves as                                                     |
-| CTRL+Alt+L   | Formats the editor using `format_command`                    |
+| CTRL+Alt+L   | Formats the editor using clang-format, format selection only if there is a selection |
 | CTRL+Shift+R | Compile and Run                                              |
 | CTRL+Shift+C | Compile only                                                 |
 | CTRL+R       | Run                                                          |

--- a/include/Formatter.hpp
+++ b/include/Formatter.hpp
@@ -1,44 +1,44 @@
 /*
-* Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com> 
-* 
-* This file is part of CPEditor.
-*  
-* CPEditor is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* I will not be responsible if CPEditor behaves in unexpected way and
-* causes your ratings to go down and or loose any important contest.
-* 
-* Believe Software is "Software" and it isn't immune to bugs.
-* 
-*/
-
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CPEditor.
+ *
+ * CPEditor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CPEditor behaves in unexpected way and
+ * causes your ratings to go down and or loose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
 
 #ifndef FORMATTER_HPP
 #define FORMATTER_HPP
-#include <BaseFiles.hpp>
 #include <MessageLogger.hpp>
 #include <QCodeEditor>
-#include <QFile>
 #include <QString>
+#include <QPair>
 
 namespace Core
 {
-class Formatter : private Base::Files
+class Formatter
 {
   public:
-    Formatter(QString runCommand, int index, MessageLogger *log);
-    ~Formatter();
-    void format(QCodeEditor *editor);
-    static bool check(QString command);
-    void updateCommand(QString newCommand);
+    Formatter(QString clangFormatBinary, const QString &clangFormatStyle, MessageLogger *log);
+    void format(QCodeEditor *editor, const QString &filePath, const QString &lang, bool selectionOnly);
+    static bool check(QString checkBinary, const QString &checkStyle);
+    void updateBinary(QString newBinary);
+    void updateStyle(const QString &newStyle);
 
   private:
-    QFile *file;
-    QString command;
+    QString binary;
+    QString style;
     MessageLogger *log;
+
+    QPair<int, QString> getFormatResult(const QStringList &args);
 };
 
 } // namespace Core

--- a/include/Formatter.hpp
+++ b/include/Formatter.hpp
@@ -19,8 +19,8 @@
 #define FORMATTER_HPP
 #include <MessageLogger.hpp>
 #include <QCodeEditor>
-#include <QString>
 #include <QPair>
+#include <QString>
 
 namespace Core
 {

--- a/include/SettingsManager.hpp
+++ b/include/SettingsManager.hpp
@@ -1,20 +1,19 @@
 /*
-* Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com> 
-* 
-* This file is part of CPEditor.
-*  
-* CPEditor is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* I will not be responsible if CPEditor behaves in unexpected way and
-* causes your ratings to go down and or loose any important contest.
-* 
-* Believe Software is "Software" and it isn't immune to bugs.
-* 
-*/
-
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CPEditor.
+ *
+ * CPEditor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CPEditor behaves in unexpected way and
+ * causes your ratings to go down and or loose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
 
 #ifndef SETTINGSMANAGER_HPP
 #define SETTINGSMANAGER_HPP
@@ -53,7 +52,8 @@ struct SettingsData
     QString runtimeArgumentsJava;
     QString runtimeArgumentsPython;
 
-    QString formatCommand;
+    QString clangFormatBinary;
+    QString clangFormatStyle;
 
     QString compileCommandJava;
     QString compileCommandCpp;
@@ -75,6 +75,7 @@ struct SettingsData
     bool isWindowMaximized;
     bool isCheckUpdateOnStartup;
     bool isUpdateCheckOnStartup;
+    bool isFormatOnSave;
 
     QKeySequence hotkeyRun;
     QKeySequence hotkeyCompile;
@@ -122,8 +123,10 @@ class SettingManager
     void setRuntimeArgumentsJava(QString command);
     void setRuntimeArgumentsPython(QString command);
 
-    QString getFormatCommand();
-    void setFormatCommand(QString command);
+    QString getClangFormatBinary();
+    void setClangFormatBinary(QString binary);
+    QString getClangFormatStyle();
+    void setClangFormatStyle(const QString &style);
 
     QString getCompileCommandCpp();
     QString getCompileCommandJava();
@@ -170,6 +173,9 @@ class SettingManager
 
     bool isCheckUpdateOnStartup();
     void checkUpdateOnStartup(bool value);
+
+    bool isFormatOnSave();
+    void formatOnSave(bool value);
 
     ViewMode getViewMode();
     void setViewMode(ViewMode v);

--- a/include/UpdateNotifier.hpp
+++ b/include/UpdateNotifier.hpp
@@ -1,20 +1,19 @@
 /*
-* Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com> 
-* 
-* This file is part of CPEditor.
-*  
-* CPEditor is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* I will not be responsible if CPEditor behaves in unexpected way and
-* causes your ratings to go down and or loose any important contest.
-* 
-* Believe Software is "Software" and it isn't immune to bugs.
-* 
-*/
-
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CPEditor.
+ *
+ * CPEditor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CPEditor behaves in unexpected way and
+ * causes your ratings to go down and or loose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
 
 #ifndef UPDATENOTIFIER_HPP
 #define UPDATENOTIFIER_HPP

--- a/include/appwindow.hpp
+++ b/include/appwindow.hpp
@@ -1,20 +1,19 @@
 /*
-* Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com> 
-* 
-* This file is part of CPEditor.
-*  
-* CPEditor is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* I will not be responsible if CPEditor behaves in unexpected way and
-* causes your ratings to go down and or loose any important contest.
-* 
-* Believe Software is "Software" and it isn't immune to bugs.
-* 
-*/
-
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CPEditor.
+ *
+ * CPEditor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CPEditor behaves in unexpected way and
+ * causes your ratings to go down and or loose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
 
 #ifndef APPWINDOW_HPP
 #define APPWINDOW_HPP

--- a/include/preferencewindow.hpp
+++ b/include/preferencewindow.hpp
@@ -1,20 +1,19 @@
 /*
-* Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com> 
-* 
-* This file is part of CPEditor.
-*  
-* CPEditor is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* I will not be responsible if CPEditor behaves in unexpected way and
-* causes your ratings to go down and or loose any important contest.
-* 
-* Believe Software is "Software" and it isn't immune to bugs.
-* 
-*/
-
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CPEditor.
+ *
+ * CPEditor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CPEditor behaves in unexpected way and
+ * causes your ratings to go down and or loose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
 
 #ifndef PREFERENCEWINDOW_HPP
 #define PREFERENCEWINDOW_HPP
@@ -61,9 +60,9 @@ class PreferenceWindow : public QMainWindow
 
     void on_load_snippets_from_file_clicked();
 
-    void on_snippets_lang_changed(const QString &lang);
+    void onSnippetsLangChanged(const QString &lang);
 
-    void on_current_snippet_changed(const QString &text);
+    void onCurrentSnippetChanged(const QString &text);
 
     void applySettingsToEditor();
 
@@ -75,7 +74,7 @@ class PreferenceWindow : public QMainWindow
 
     void on_snippet_rename_clicked();
 
-private:
+  private:
     Ui::PreferenceWindow *ui;
     QFont currentFont;
     QString cppTemplatePath, pythonTemplatePath, javaTemplatePath;
@@ -88,7 +87,7 @@ private:
     void updateSnippets();
     void switchToSnippet(const QString &text);
 
-    QString getNewSnippetName(const QString& lang, const QString &old = QString());
+    QString getNewSnippetName(const QString &lang, const QString &old = QString());
 };
 
 #endif // PREFERENCEWINDOW_HPP

--- a/src/DiffViewer.cpp
+++ b/src/DiffViewer.cpp
@@ -1,20 +1,19 @@
 /*
-* Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com> 
-* 
-* This file is part of CPEditor.
-*  
-* CPEditor is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* I will not be responsible if CPEditor behaves in unexpected way and
-* causes your ratings to go down and or loose any important contest.
-* 
-* Believe Software is "Software" and it isn't immune to bugs.
-* 
-*/
-
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CPEditor.
+ *
+ * CPEditor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CPEditor behaves in unexpected way and
+ * causes your ratings to go down and or loose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
 
 #include "DiffViewer.hpp"
 

--- a/src/Formatter.cpp
+++ b/src/Formatter.cpp
@@ -1,108 +1,168 @@
 /*
-* Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com> 
-* 
-* This file is part of CPEditor.
-*  
-* CPEditor is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* I will not be responsible if CPEditor behaves in unexpected way and
-* causes your ratings to go down and or loose any important contest.
-* 
-* Believe Software is "Software" and it isn't immune to bugs.
-* 
-*/
-
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CPEditor.
+ *
+ * CPEditor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CPEditor behaves in unexpected way and
+ * causes your ratings to go down and or loose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
 
 #include <Formatter.hpp>
+#include <QJsonDocument>
 #include <QProcess>
+#include <QTemporaryDir>
 
 namespace Core
 {
-Formatter::Formatter(QString runCommand, int index, MessageLogger *log) : Base::Files(index)
+Formatter::Formatter(QString clangFormatBinary, const QString &clangFormatStyle, MessageLogger *log)
 {
     this->log = log;
-    command = runCommand;
-    file = new QFile(getTempFormatFile());
-    file->open(QIODevice::ReadWrite | QFile::Text);
-    if (!file->isOpen())
+    updateBinary(clangFormatBinary);
+    updateStyle(clangFormatStyle);
+}
+
+bool Formatter::check(QString checkBinary, const QString &checkStyle)
+{
+    QTemporaryDir tmpDir;
+    if (!tmpDir.isValid())
+        return false;
+    QFile tmpFile(tmpDir.filePath("tmp.cpp"));
+    tmpFile.open(QIODevice::WriteOnly | QIODevice::Text);
+    tmpFile.write("int main(){}");
+    tmpFile.close();
+    QFile styleFile(tmpDir.filePath(".clang-format"));
+    styleFile.open(QIODevice::WriteOnly | QIODevice::Text);
+    styleFile.write(checkStyle.toStdString().c_str());
+    styleFile.close();
+    QProcess program;
+    program.start(checkBinary, {"--cursor=0", "--offset=0", "--length=0", "--style=file", tmpFile.fileName()});
+    if (!program.waitForFinished(2000))
+        program.kill();
+    return program.exitCode() == 0;
+}
+
+void Formatter::updateBinary(QString newBinary)
+{
+    binary = newBinary;
+}
+
+void Formatter::updateStyle(const QString &newStyle)
+{
+    style = newStyle;
+}
+
+void Formatter::format(QCodeEditor *editor, const QString &filePath, const QString &lang, bool selectionOnly)
+{
+    auto cursor = editor->textCursor();
+    int start = cursor.selectionStart();
+    int end = cursor.selectionEnd();
+    int pos = cursor.position();
+
+    QStringList args = {"--cursor=" + QString::number(pos), "--style=file"};
+
+    if (selectionOnly && cursor.hasSelection())
     {
-        log->warn("Formatter", "Cannot create temporary format file");
+        args.append("--offset=" + QString::number(start));
+        args.append("--length=" + QString::number(end - start));
+    }
+
+    QString tmpName = "tmp.cpp";
+    if (filePath.isEmpty())
+    {
+        if (lang == "Java")
+            tmpName = "tmp.java";
+        else if (lang == "Python")
+            tmpName = "tmp.py";
     }
     else
     {
-        file->resize(0);
+        tmpName = QFileInfo(filePath).fileName();
     }
-}
 
-Formatter::~Formatter()
-{
-    if (file->isOpen())
-        file->close();
-    delete file;
-}
-
-bool Formatter::check(QString command)
-{
-    auto results = command.trimmed().split(" ");
-    QProcess program;
-    QString commandToStart = results[0];
-    QStringList environment = program.systemEnvironment();
-    program.start(commandToStart + " --version");
-    bool started = program.waitForStarted();
-    if (started) // 10 Second timeout
-        program.kill();
-
-    return started;
-}
-
-void Formatter::updateCommand(QString newCommand)
-{
-    command = newCommand;
-}
-
-void Formatter::format(QCodeEditor *editor)
-{
-    auto old_pos = editor->textCursor();
-    auto old = editor->toPlainText().toStdString();
-    if (file->isOpen())
+    QTemporaryDir tmpDir;
+    if (!tmpDir.isValid())
     {
-        file->resize(0);
-        file->write(old.c_str());
-        file->close();
-        auto result = command.trimmed().split(" ");
-        QProcess formatProcess;
-        QString programName = result[0];
-        result.removeAt(0);
-        result.append(getTempFormatFile());
-
-        formatProcess.start(programName, result);
-        formatProcess.waitForFinished(2000); // BLOCKS main Thread
-
-        if (formatProcess.state() == QProcess::Running)
-        {
-            log->warn("Formatter", "It seems the format command took more than 2 seconds to complete. Skipped");
-            file->open(QIODevice::ReadWrite | QFile::Text);
-            return;
-        }
-
-        if (formatProcess.exitCode() != 0)
-        {
-            log->error("Formatter",
-                       "Format command returned non-zero exit code " + std::to_string(formatProcess.exitCode()));
-            file->open(QIODevice::ReadWrite | QFile::Text);
-            return;
-        }
-
-        file->open(QIODevice::ReadWrite | QFile::Text);
-        auto doc = editor->document();
-        QTextCursor cursor(doc);
-        cursor.select(QTextCursor::Document);
-        cursor.insertText(formatProcess.readAllStandardOutput());
-        editor->setTextCursor(old_pos);
-        log->info("Formatter", "Formatting completed");
+        log->error("Formatter", "Failed to create temporary directory");
+        return;
     }
-};
+    QFile tmpFile(tmpDir.filePath(tmpName));
+    tmpFile.open(QIODevice::WriteOnly | QIODevice::Text);
+    tmpFile.write(editor->toPlainText().toStdString().c_str());
+    tmpFile.close();
+    QFile styleFile(tmpDir.filePath(".clang-format"));
+    styleFile.open(QIODevice::WriteOnly | QIODevice::Text);
+    styleFile.write(style.toStdString().c_str());
+    styleFile.close();
+
+    args.append(tmpFile.fileName());
+
+    auto res = getFormatResult(args);
+    if (res.first == -1)
+        return;
+
+    cursor.select(QTextCursor::Document);
+    cursor.insertText(res.second);
+    cursor.setPosition(res.first);
+
+    if (start != end)
+    {
+        if (pos == end)
+            args[0] = "--cursor=" + QString::number(start);
+        else
+            args[0] = "--cursor=" + QString::number(end);
+        auto res2 = getFormatResult(args);
+        if (res2.first == -1)
+            return;
+        cursor.setPosition(res2.first, QTextCursor::MoveAnchor);
+        cursor.setPosition(res.first, QTextCursor::KeepAnchor);
+    }
+
+    editor->setTextCursor(cursor);
+
+    log->info("Formatter", "Formatting completed");
+}
+
+QPair<int, QString> Formatter::getFormatResult(const QStringList &args)
+{
+    QProcess formatProcess;
+    formatProcess.start(binary, args);
+    formatProcess.waitForFinished(2000); // BLOCKS main Thread
+
+    if (formatProcess.state() == QProcess::Running)
+    {
+        formatProcess.kill();
+        log->warn("Formatter", "The format command is: " + binary.toStdString() + " " + args.join(' ').toStdString());
+        log->warn("Formatter", "It seems the formatting took more than 2 seconds to complete. Skipped");
+        return QPair<int, QString>(-1, QString());
+    }
+
+    if (formatProcess.exitCode() != 0)
+    {
+        log->warn("Formatter", "The format command is: " + binary.toStdString() + " " + args.join(' ').toStdString());
+        auto stdOut = formatProcess.readAllStandardOutput();
+        if (!stdOut.isEmpty())
+            log->warn("Formatter[stdout]", stdOut.toStdString(), true);
+        auto stdError = formatProcess.readAllStandardError();
+        if (!stdError.isEmpty())
+            log->error("Formatter[stderr]", stdError.toStdString(), true);
+        return QPair<int, QString>(-1, QString());
+    }
+
+    auto result = formatProcess.readAllStandardOutput();
+    int firstNewLine = result.indexOf('\n');
+    QString jsonLine = result.left(firstNewLine);
+    auto formattedCodes = result.mid(firstNewLine + 1);
+    auto json = QJsonDocument::fromJson(jsonLine.toLocal8Bit());
+    int newCursorPos = json["Cursor"].toInt();
+
+    return QPair<int, QString>(newCursorPos, formattedCodes);
+}
 } // namespace Core

--- a/src/SettingsManager.cpp
+++ b/src/SettingsManager.cpp
@@ -1,20 +1,19 @@
 /*
-* Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com> 
-* 
-* This file is part of CPEditor.
-*  
-* CPEditor is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* I will not be responsible if CPEditor behaves in unexpected way and
-* causes your ratings to go down and or loose any important contest.
-* 
-* Believe Software is "Software" and it isn't immune to bugs.
-* 
-*/
-
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CPEditor.
+ *
+ * CPEditor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CPEditor behaves in unexpected way and
+ * causes your ratings to go down and or loose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
 
 #include <MessageLogger.hpp>
 #include <QApplication>
@@ -80,6 +79,10 @@ bool SettingManager::isHotkeyInUse()
 {
     return mSettings->value("hotkey_use", "false").toBool();
 }
+bool SettingManager::isFormatOnSave()
+{
+    return mSettings->value("format_on_save", "false").toBool();
+}
 
 QString SettingManager::getRunCommandJava()
 {
@@ -97,9 +100,13 @@ QString SettingManager::getCompileCommandJava()
 {
     return mSettings->value("compile_java", "javac").toString();
 }
-QString SettingManager::getFormatCommand()
+QString SettingManager::getClangFormatBinary()
 {
-    return mSettings->value("format", "clang-format").toString();
+    return mSettings->value("clang_format_binary", "clang-format").toString();
+}
+QString SettingManager::getClangFormatStyle()
+{
+    return mSettings->value("clang_format_style", "BasedOnStyle: Google").toString();
 }
 QString SettingManager::getRuntimeArgumentsCpp()
 {
@@ -234,6 +241,14 @@ void SettingManager::setHotKeyInUse(bool value)
         mSettings->setValue("hotkey_use", QString::fromStdString("false"));
 }
 
+void SettingManager::formatOnSave(bool value)
+{
+    if (value)
+        mSettings->setValue("format_on_save", QString::fromStdString("true"));
+    else
+        mSettings->setValue("format_on_save", QString::fromStdString("false"));
+}
+
 void SettingManager::setTabStop(int num)
 {
     mSettings->setValue("tab_stop", num);
@@ -268,9 +283,13 @@ void SettingManager::setCompileCommandsJava(QString command)
 {
     mSettings->setValue("compile_java", command);
 }
-void SettingManager::setFormatCommand(QString value)
+void SettingManager::setClangFormatBinary(QString binary)
 {
-    mSettings->setValue("format", value);
+    mSettings->setValue("clang_format_binary", binary);
+}
+void SettingManager::setClangFormatStyle(const QString &style)
+{
+    mSettings->setValue("clang_format_style", style);
 }
 void SettingManager::setTemplatePathCpp(QString path)
 {
@@ -444,7 +463,8 @@ SettingsData SettingManager::toData()
     data.runtimeArgumentsCpp = getRuntimeArgumentsCpp();
     data.runtimeArgumentsJava = getRuntimeArgumentsJava();
     data.runtimeArgumentsPython = getRuntimeArgumentsPython();
-    data.formatCommand = getFormatCommand();
+    data.clangFormatBinary = getClangFormatBinary();
+    data.clangFormatStyle = getClangFormatStyle();
     data.compileCommandCpp = getCompileCommandCpp();
     data.compileCommandJava = getCompileCommandJava();
     data.runCommandJava = getRunCommandJava();
@@ -461,6 +481,7 @@ SettingsData SettingManager::toData()
     data.isCompanionActive = isCompetitiveCompanionActive();
     data.isWindowMaximized = isMaximizedWindow();
     data.isCheckUpdateOnStartup = isCheckUpdateOnStartup();
+    data.isFormatOnSave = isFormatOnSave();
     data.hotkeyCompile = getHotkeyCompile();
     data.hotkeyRun = getHotkeyRun();
     data.hotkeyCompileRun = getHotkeyCompileRun();

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -1,20 +1,19 @@
 /*
-* Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com> 
-* 
-* This file is part of CPEditor.
-*  
-* CPEditor is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* I will not be responsible if CPEditor behaves in unexpected way and
-* causes your ratings to go down and or loose any important contest.
-* 
-* Believe Software is "Software" and it isn't immune to bugs.
-* 
-*/
-
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CPEditor.
+ *
+ * CPEditor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CPEditor behaves in unexpected way and
+ * causes your ratings to go down and or loose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
 
 #include "appwindow.hpp"
 #include "../ui/ui_appwindow.h"
@@ -461,10 +460,6 @@ void AppWindow::onSaveTimerElapsed()
 
 void AppWindow::onSettingsApplied()
 {
-
-    if (settingManager->getFormatCommand().contains(QRegularExpression(" -i(?: |$)")))
-        QMessageBox::warning(this, "Formatter", "Please don't use -i in the format command.");
-
     updater->setBeta(settingManager->isBeta());
     maybeSetHotkeys();
 

--- a/src/cftools.cpp
+++ b/src/cftools.cpp
@@ -1,20 +1,19 @@
 /*
-* Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com> 
-* 
-* This file is part of CPEditor.
-*  
-* CPEditor is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* I will not be responsible if CPEditor behaves in unexpected way and
-* causes your ratings to go down and or loose any important contest.
-* 
-* Believe Software is "Software" and it isn't immune to bugs.
-* 
-*/
-
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CPEditor.
+ *
+ * CPEditor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CPEditor behaves in unexpected way and
+ * causes your ratings to go down and or loose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
 
 #include "cftools.hpp"
 #include <QDebug>

--- a/src/editortheme.cpp
+++ b/src/editortheme.cpp
@@ -1,20 +1,19 @@
 /*
-* Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com> 
-* 
-* This file is part of CPEditor.
-*  
-* CPEditor is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* I will not be responsible if CPEditor behaves in unexpected way and
-* causes your ratings to go down and or loose any important contest.
-* 
-* Believe Software is "Software" and it isn't immune to bugs.
-* 
-*/
-
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CPEditor.
+ *
+ * CPEditor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CPEditor behaves in unexpected way and
+ * causes your ratings to go down and or loose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
 
 #include "EditorTheme.hpp"
 

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -1,20 +1,19 @@
 /*
-* Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com> 
-* 
-* This file is part of CPEditor.
-*  
-* CPEditor is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* I will not be responsible if CPEditor behaves in unexpected way and
-* causes your ratings to go down and or loose any important contest.
-* 
-* Believe Software is "Software" and it isn't immune to bugs.
-* 
-*/
-
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CPEditor.
+ *
+ * CPEditor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CPEditor behaves in unexpected way and
+ * causes your ratings to go down and or loose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
 
 #include <MessageLogger.hpp>
 #include <QFileDialog>

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,20 +1,19 @@
 /*
-* Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com> 
-* 
-* This file is part of CPEditor.
-*  
-* CPEditor is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* I will not be responsible if CPEditor behaves in unexpected way and
-* causes your ratings to go down and or loose any important contest.
-* 
-* Believe Software is "Software" and it isn't immune to bugs.
-* 
-*/
-
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CPEditor.
+ *
+ * CPEditor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CPEditor behaves in unexpected way and
+ * causes your ratings to go down and or loose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
 
 #include <QApplication>
 

--- a/src/preferencewindow.cpp
+++ b/src/preferencewindow.cpp
@@ -1,20 +1,19 @@
 /*
-* Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com> 
-* 
-* This file is part of CPEditor.
-*  
-* CPEditor is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-* 
-* I will not be responsible if CPEditor behaves in unexpected way and
-* causes your ratings to go down and or loose any important contest.
-* 
-* Believe Software is "Software" and it isn't immune to bugs.
-* 
-*/
-
+ * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
+ *
+ * This file is part of CPEditor.
+ *
+ * CPEditor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * I will not be responsible if CPEditor behaves in unexpected way and
+ * causes your ratings to go down and or loose any important contest.
+ *
+ * Believe Software is "Software" and it isn't immune to bugs.
+ *
+ */
 
 #include "include/preferencewindow.hpp"
 #include "../ui/ui_preferencewindow.h"
@@ -41,9 +40,9 @@ PreferenceWindow::PreferenceWindow(Settings::SettingManager *manager, QWidget *p
     ui->verticalLayout_3->insertWidget(0, editor);
 
     connect(ui->snippets, SIGNAL(currentTextChanged(const QString &)), this,
-            SLOT(on_current_snippet_changed(const QString &)));
+            SLOT(onCurrentSnippetChanged(const QString &)));
     connect(ui->snippets_lang, SIGNAL(currentTextChanged(const QString &)), this,
-            SLOT(on_snippets_lang_changed(const QString &)));
+            SLOT(onSnippetsLangChanged(const QString &)));
 
     applySettingsToui();
     resize(QDesktopWidget().availableGeometry(this).size() * 0.40);
@@ -92,9 +91,9 @@ void PreferenceWindow::applySettingsToui()
     ui->indent->setChecked(manager->isAutoIndent());
     ui->parentheses->setChecked(manager->isAutoParenthesis());
     ui->replace_tabs->setChecked(manager->isTabsReplaced());
+    ui->format_on_save->setChecked(manager->isFormatOnSave());
 
     ui->defaultLang->setCurrentText(manager->getDefaultLang());
-    ui->format_cmd->setText(manager->getFormatCommand());
 
     ui->cpp_compiler_cmd->setText(manager->getCompileCommandCpp());
     ui->cpp_args_cmd->setText(manager->getRuntimeArgumentsCpp());
@@ -108,6 +107,9 @@ void PreferenceWindow::applySettingsToui()
 
     ui->companion_use->setChecked(manager->isCompetitiveCompanionActive());
     ui->companion_port->setValue(manager->getConnectionPort());
+
+    ui->clang_format_binary->setText(manager->getClangFormatBinary());
+    ui->clang_format_style->setPlainText(manager->getClangFormatStyle());
 
     cppTemplatePath = manager->getTemplatePathCpp();
     pythonTemplatePath = manager->getTemplatePathPython();
@@ -135,7 +137,7 @@ void PreferenceWindow::applySettingsToui()
     int lang_index = ui->snippets_lang->findText(lang);
     if (lang_index != -1)
         ui->snippets_lang->setCurrentIndex(lang_index);
-    on_snippets_lang_changed(lang);
+    onSnippetsLangChanged(lang);
 }
 
 void PreferenceWindow::extractSettingsFromUi()
@@ -149,9 +151,9 @@ void PreferenceWindow::extractSettingsFromUi()
     manager->setAutoIndent(ui->indent->isChecked());
     manager->setAutoParenthesis(ui->parentheses->isChecked());
     manager->setTabsReplaced(ui->replace_tabs->isChecked());
+    manager->formatOnSave(ui->format_on_save->isChecked());
 
     manager->setDefaultLanguage(ui->defaultLang->currentText());
-    manager->setFormatCommand(ui->format_cmd->text());
 
     manager->setCompileCommandsCpp(ui->cpp_compiler_cmd->text());
     manager->setRuntimeArgumentsCpp(ui->cpp_args_cmd->text());
@@ -162,6 +164,9 @@ void PreferenceWindow::extractSettingsFromUi()
 
     manager->setRunCommandPython(ui->python_start_cmd->text());
     manager->setRuntimeArgumentsPython(ui->python_args_cmd->text());
+
+    manager->setClangFormatBinary(ui->clang_format_binary->text());
+    manager->setClangFormatStyle(ui->clang_format_style->toPlainText());
 
     manager->setCompetitiveCompanionActive(ui->companion_use->isChecked());
     manager->setConnectionPort(ui->companion_port->value());
@@ -301,7 +306,7 @@ void PreferenceWindow::on_load_snippets_from_file_clicked()
     }
 }
 
-void PreferenceWindow::on_snippets_lang_changed(const QString &lang)
+void PreferenceWindow::onSnippetsLangChanged(const QString &lang)
 {
     updateSnippets();
     if (lang == "Python")
@@ -321,7 +326,7 @@ void PreferenceWindow::on_snippets_lang_changed(const QString &lang)
     }
 }
 
-void PreferenceWindow::on_current_snippet_changed(const QString &text)
+void PreferenceWindow::onCurrentSnippetChanged(const QString &text)
 {
     auto lang = ui->snippets_lang->currentText();
     auto content = manager->getSnippet(lang, text);

--- a/ui/preferencewindow.ui
+++ b/ui/preferencewindow.ui
@@ -208,10 +208,7 @@
                  </widget>
                 </item>
                 <item row="7" column="0">
-                 <widget class="QCheckBox" name="checkBox_9">
-                  <property name="enabled">
-                   <bool>false</bool>
-                  </property>
+                 <widget class="QCheckBox" name="format_on_save">
                   <property name="text">
                    <string>Automatically format source on save</string>
                   </property>
@@ -280,16 +277,6 @@
                  </property>
                 </item>
                </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_34">
-                <property name="text">
-                 <string>Format command</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QLineEdit" name="format_cmd"/>
               </item>
              </layout>
             </item>
@@ -437,6 +424,37 @@
                <widget class="QLineEdit" name="python_start_cmd"/>
               </item>
              </layout>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="formatting">
+         <attribute name="title">
+          <string>Formatting</string>
+         </attribute>
+         <layout class="QHBoxLayout" name="horizontalLayout_6">
+          <item>
+           <layout class="QFormLayout" name="formLayout_8">
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_34">
+              <property name="text">
+               <string>Clang Format Binary</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLineEdit" name="clang_format_binary"/>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_34">
+              <property name="text">
+               <string>Clang Format Style</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QPlainTextEdit" name="clang_format_style"/>
             </item>
            </layout>
           </item>


### PR DESCRIPTION
1. Set clang-format binary instead of set format command.

2. Use `--cursor` argument to keep the cursor after formatting.

3. Format selection only if there is a selection.

4. Set format style in preference window.

5. Add format on save option.

6. Open temporary file for formatting when necessary instead of holding it.

7. Other text changes and minor changes.

8. Modify README.md for these changes.

This closes #81 .