### PR TITLE
feat: make file logic like Sublime

### DIFF
--- a/include/appwindow.hpp
+++ b/include/appwindow.hpp
@@ -55,7 +55,7 @@ class AppWindow : public QMainWindow
 
     void onTabCloseRequested(int);
     void onTabChanged(int);
-    void onEditorTextChanged(bool, MainWindow *);
+    void onEditorChanged(MainWindow *);
     void onSaveTimerElapsed();
     void onSettingsApplied();
     void onSplitterMoved(int, int);

--- a/include/mainwindow.hpp
+++ b/include/mainwindow.hpp
@@ -24,6 +24,7 @@
 #include <IO.hpp>
 #include <QCodeEditor>
 #include <QFile>
+#include <QFileSystemWatcher>
 #include <QLabel>
 #include <QMainWindow>
 #include <QPushButton>
@@ -47,12 +48,21 @@ class MainWindow : public QMainWindow
     Q_OBJECT
 
   public:
+    enum SaveMode
+    {
+        IgnoreUntitled = 0, // save only when filePath is not empty
+        SaveUntitled = 1,   // save to filePath if it's not empty, otherwise ask for new path
+        SaveAs = 3          // ask for new path no matter filePath is empty or not
+    };
+
     MainWindow(int index, QString fileOpen, QWidget *parent = nullptr);
     ~MainWindow() override;
 
-    QString fileName() const;
-    QString filePath() const;
-    QString problemURL() const;
+    QString getFileName() const;
+    QString getFilePath() const;
+    QString getProblemURL() const;
+    QString getTabTitle(bool complete) const;
+    bool isUntitled() const;
     void save(bool force);
     void saveAs();
 
@@ -73,7 +83,6 @@ class MainWindow : public QMainWindow
     void setSettingsData(Settings::SettingsData data, bool);
 
     MessageLogger *getLogger();
-    QFile *getOpenFile();
     QSplitter *getSplitter();
 
     void insertText(QString text);
@@ -99,10 +108,12 @@ class MainWindow : public QMainWindow
     void on_out2_diff_clicked();
     void on_out3_diff_clicked();
 
-    void on_changeLanguageButoon_clicked();
+    void on_changeLanguageButton_clicked();
+
+    void onFileWatcherChanged(const QString &);
 
   signals:
-    void editorTextChanged(bool isUnsaved, MainWindow *widget);
+    void editorChanged(MainWindow *widget);
     void confirmTriggered(MainWindow *widget);
 
   private:
@@ -110,7 +121,6 @@ class MainWindow : public QMainWindow
     Ui::MainWindow *ui;
     QCodeEditor *editor;
     QString language;
-    QFile *openFile = nullptr;
     Settings::SettingsData data;
     bool isLanguageSet = false;
 
@@ -120,11 +130,15 @@ class MainWindow : public QMainWindow
     Core::Runner *runner = nullptr;
     MessageLogger log;
 
+    QString problemURL;
+    QString filePath;
+    QString savedText;
+    QFileSystemWatcher *fileWatcher = nullptr;
+
     QVector<QPlainTextEdit *> input = QVector<QPlainTextEdit *>(3, nullptr);
     QVector<QPlainTextEdit *> output = QVector<QPlainTextEdit *>(3, nullptr);
     QVector<QLabel *> verdict = QVector<QLabel *>(3, nullptr);
     QVector<QString *> expected = QVector<QString *>(3, nullptr);
-    Network::CompanionData companionData;
     QPushButton *submitToCodeforces = nullptr;
     Network::CFTools *cftools = nullptr;
 
@@ -135,10 +149,11 @@ class MainWindow : public QMainWindow
     void saveTests();
     void setCFToolsUI();
     void updateVerdict(Core::Verdict, int);
-    bool isTextChanged();
-
+    bool isTextChanged() const;
     bool isVerdictPass(QString, QString);
-    bool saveFile(bool, std::string);
+    void setText(const QString &text, bool saveCursor = false);
+    void loadFile(const QString &path);
+    bool saveFile(SaveMode, std::string);
     void performCoreDiagonistics();
 };
 #endif // MAINWINDOW_HPP

--- a/src/appwindow.cpp
+++ b/src/appwindow.cpp
@@ -4,6 +4,7 @@
 #include <QDesktopServices>
 #include <QFileDialog>
 #include <QInputDialog>
+#include <QMap>
 #include <QMessageBox>
 #include <QMetaMethod>
 #include <QMimeData>
@@ -31,7 +32,7 @@ AppWindow::AppWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::AppWindo
     setConnections();
 
     auto windowTemp = new MainWindow(0, "");
-    ui->tabWidget->addTab(windowTemp, windowTemp->fileName());
+    ui->tabWidget->addTab(windowTemp, windowTemp->getFileName());
 
     if (settingManager->isCheckUpdateOnStartup())
         updater->checkUpdate();
@@ -220,7 +221,7 @@ void AppWindow::openTab(QString fileName, bool iscompanionOpenedTab)
             for (int t = 0; t < ui->tabWidget->count(); t++)
             {
                 auto tmp = dynamic_cast<MainWindow *>(ui->tabWidget->widget(t));
-                if (fileName == tmp->filePath())
+                if (fileName == tmp->getFilePath())
                 {
                     ui->tabWidget->setCurrentIndex(t);
                     return;
@@ -232,8 +233,7 @@ void AppWindow::openTab(QString fileName, bool iscompanionOpenedTab)
         auto fsp = new MainWindow(t, fileName);
         fsp->setSettingsData(settingManager->toData(), true);
         connect(fsp, SIGNAL(confirmTriggered(MainWindow *)), this, SLOT(on_confirmTriggered(MainWindow *)));
-        connect(fsp, SIGNAL(editorTextChanged(bool, MainWindow *)), this,
-                SLOT(onEditorTextChanged(bool, MainWindow *)));
+        connect(fsp, SIGNAL(editorChanged(MainWindow *)), this, SLOT(onEditorChanged(MainWindow *)));
         QString lang = settingManager->getDefaultLang();
 
         if (fileName.endsWith(".java"))
@@ -244,7 +244,7 @@ void AppWindow::openTab(QString fileName, bool iscompanionOpenedTab)
                  fileName.endsWith(".cc") || fileName.endsWith(".hpp") || fileName.endsWith(".h"))
             lang = "Cpp";
 
-        ui->tabWidget->addTab(fsp, fsp->fileName());
+        ui->tabWidget->addTab(fsp, fsp->getFileName());
         fsp->setLanguage(lang);
         ui->tabWidget->setCurrentIndex(t);
     }
@@ -253,7 +253,7 @@ void AppWindow::openTab(QString fileName, bool iscompanionOpenedTab)
         for (int t = 0; t < ui->tabWidget->count(); t++)
         {
             auto tmp = windowIndex(t);
-            if (fileName == tmp->problemURL())
+            if (fileName == tmp->getProblemURL())
             {
                 ui->tabWidget->setCurrentIndex(t);
                 return;
@@ -264,9 +264,8 @@ void AppWindow::openTab(QString fileName, bool iscompanionOpenedTab)
         auto fsp = new MainWindow(t, "");
         fsp->setSettingsData(settingManager->toData(), true);
         connect(fsp, SIGNAL(confirmTriggered(MainWindow *)), this, SLOT(on_confirmTriggered(MainWindow *)));
-        connect(fsp, SIGNAL(editorTextChanged(bool, MainWindow *)), this,
-                SLOT(onEditorTextChanged(bool, MainWindow *)));
-        ui->tabWidget->addTab(fsp, fsp->fileName());
+        connect(fsp, SIGNAL(editorChanged(MainWindow *)), this, SLOT(onEditorChanged(MainWindow *)));
+        ui->tabWidget->addTab(fsp, fsp->getFileName());
         ui->tabWidget->setCurrentIndex(t);
     }
 }
@@ -382,7 +381,7 @@ void AppWindow::onTabChanged(int index)
     {
         activeLogger = nullptr;
         server->setMessageLogger(nullptr);
-        setWindowTitle("CP Editor: Competitive Programmers Editor");
+        setWindowTitle("CP Editor: An editor specially designed for competitive programming");
         return;
     }
 
@@ -390,10 +389,10 @@ void AppWindow::onTabChanged(int index)
 
     auto tmp = windowIndex(index);
 
-    if (tmp->getOpenFile() == nullptr)
-        setWindowTitle("CP Editor: " + tmp->fileName());
+    if (tmp->isUntitled())
+        setWindowTitle("CP Editor: " + tmp->getFileName());
     else
-        setWindowTitle("CP Editor: " + tmp->filePath());
+        setWindowTitle("CP Editor: " + tmp->getFilePath());
 
     activeLogger = tmp->getLogger();
     server->setMessageLogger(activeLogger);
@@ -416,16 +415,30 @@ void AppWindow::onTabChanged(int index)
         connect(tmp->getSplitter(), SIGNAL(splitterMoved(int, int)), this, SLOT(onSplitterMoved(int, int)));
 }
 
-void AppWindow::onEditorTextChanged(bool isUnsaved, MainWindow *widget)
+void AppWindow::onEditorChanged(MainWindow *widget)
 {
-    int index = ui->tabWidget->indexOf(widget);
-    if (index == -1)
-        return;
-    auto name = windowIndex(index)->fileName();
-    if (isUnsaved)
-        ui->tabWidget->setTabText(index, name + " *");
-    else
-        ui->tabWidget->setTabText(index, name);
+    if (widget == currentWindow())
+    {
+        if (widget->isUntitled())
+            setWindowTitle("CP Editor: " + widget->getFileName());
+        else
+            setWindowTitle("CP Editor: " + widget->getFilePath());
+    }
+
+    QMap<QString, QVector<int>> tabsByName;
+
+    for (int t = 0; t < ui->tabWidget->count(); ++t)
+    {
+        tabsByName[windowIndex(t)->getFileName()].push_back(t);
+    }
+
+    for (auto tabs : tabsByName)
+    {
+        for (auto index : tabs)
+        {
+            ui->tabWidget->setTabText(index, windowIndex(index)->getTabTitle(tabs.size() > 1));
+        }
+    }
 }
 
 void AppWindow::onSaveTimerElapsed()
@@ -433,9 +446,8 @@ void AppWindow::onSaveTimerElapsed()
     for (int t = 0; t < ui->tabWidget->count(); t++)
     {
         auto tmp = windowIndex(t);
-        if (tmp->getOpenFile() != nullptr && tmp->getOpenFile()->isOpen())
+        if (!tmp->isUntitled())
         {
-            ui->tabWidget->setTabText(t, tmp->fileName());
             tmp->save(false);
         }
     }

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -133,7 +133,7 @@
              </spacer>
             </item>
             <item>
-             <widget class="QPushButton" name="changeLanguageButoon">
+             <widget class="QPushButton" name="changeLanguageButton">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
                 <horstretch>0</horstretch>


### PR DESCRIPTION
1. Open file when necessary instead of holding it.

2. Watch file changes on disk.

3. Show complete path when multiple tabs are of the same name.

4. Change language when saving unsaved files / saving as.

5. Text changes and other minor changes.

Please test these changes. I think there might be some bugs, especially when handling read/write file fails, and things related to problemURL.