### PR TITLE
Attempt to fix cf-tool can't find

### DIFF
--- a/src/cftools.cpp
+++ b/src/cftools.cpp
@@ -63,7 +63,7 @@ void CFTools::submit(const QString &filePath, const QString &url, const QString 
         }
     }
 
-    CFToolProcess->setProgram("cf");
+    CFToolProcess->setProgram("/usr/local/bin/cf");
     CFToolProcess->setArguments({"submit", problemContestId, problemCode, filePath});
     connect(CFToolProcess, SIGNAL(readyReadStandardOutput()), this, SLOT(onReadReady()));
     CFToolProcess->start();
@@ -72,7 +72,7 @@ void CFTools::submit(const QString &filePath, const QString &url, const QString 
 bool CFTools::check()
 {
     QProcess checkProcess;
-    checkProcess.start("cf --version");
+    checkProcess.start("/usr/local/bin/cf --version");
     bool finished = checkProcess.waitForFinished(2000);
     return finished && checkProcess.exitCode() == 0;
 }

--- a/src/cftools.cpp
+++ b/src/cftools.cpp
@@ -17,6 +17,13 @@
 
 #include "cftools.hpp"
 #include <QUrl>
+#include <string>
+
+#ifdef CFTOOL_ON_MAC
+const std::string cftool_prefix = "/usr/local/bin/";
+#else
+const std::string cftool_prefix = "";
+#endif
 
 namespace Network
 {
@@ -63,7 +70,7 @@ void CFTools::submit(const QString &filePath, const QString &url, const QString 
         }
     }
 
-    CFToolProcess->setProgram("/usr/local/bin/cf");
+    CFToolProcess->setProgram(cftool_prefix + "cf");
     CFToolProcess->setArguments({"submit", problemContestId, problemCode, filePath});
     connect(CFToolProcess, SIGNAL(readyReadStandardOutput()), this, SLOT(onReadReady()));
     CFToolProcess->start();
@@ -72,7 +79,7 @@ void CFTools::submit(const QString &filePath, const QString &url, const QString 
 bool CFTools::check()
 {
     QProcess checkProcess;
-    checkProcess.start("/usr/local/bin/cf --version");
+    checkProcess.start(cftool_prefix + "cf --version");
     bool finished = checkProcess.waitForFinished(2000);
     return finished && checkProcess.exitCode() == 0;
 }

--- a/src/cftools.cpp
+++ b/src/cftools.cpp
@@ -70,7 +70,7 @@ void CFTools::submit(const QString &filePath, const QString &url, const QString 
         }
     }
 
-    CFToolProcess->setProgram(cftool_prefix + "cf");
+    CFToolProcess->setProgram((cftool_prefix + "cf").c_str());
     CFToolProcess->setArguments({"submit", problemContestId, problemCode, filePath});
     connect(CFToolProcess, SIGNAL(readyReadStandardOutput()), this, SLOT(onReadReady()));
     CFToolProcess->start();
@@ -79,7 +79,7 @@ void CFTools::submit(const QString &filePath, const QString &url, const QString 
 bool CFTools::check()
 {
     QProcess checkProcess;
-    checkProcess.start(cftool_prefix + "cf --version");
+    checkProcess.start((cftool_prefix + "cf --version").c_str());
     bool finished = checkProcess.waitForFinished(2000);
     return finished && checkProcess.exitCode() == 0;
 }

--- a/src/cftools.cpp
+++ b/src/cftools.cpp
@@ -19,7 +19,7 @@
 #include <QUrl>
 #include <string>
 
-#ifdef CFTOOL_ON_MAC
+#ifdef __APPLE__
 const std::string cftool_prefix = "/usr/local/bin/";
 #else
 const std::string cftool_prefix = "";


### PR DESCRIPTION
I have literally zero knowledge of qt so I can't make a fancy dialog to ask the user what the cf-tool path is, but I think this *should* work on my system and most other systems. It's generally advised to put user binaries in /usr/local/bin and not /usr/bin anyways.