### PR TITLE
Add a dot at the front of the name of the config file

### DIFF
--- a/include/Core/SettingsManager.hpp
+++ b/include/Core/SettingsManager.hpp
@@ -25,6 +25,7 @@
 #include <string>
 
 #define SETTINGS_FILE "cp_editor_settings.ini"
+#define NEW_SETTINGS_FILE ".cp_editor_settings.ini"
 
 namespace Settings
 {

--- a/include/Core/SettingsManager.hpp
+++ b/include/Core/SettingsManager.hpp
@@ -24,7 +24,7 @@
 #include <QString>
 #include <string>
 
-#define SETTINGS_FILE "cp_editor_settings.ini"
+#define OLD_SETTINGS_FILE "cp_editor_settings.ini"
 #define NEW_SETTINGS_FILE ".cp_editor_settings.ini"
 
 namespace Settings

--- a/include/Core/SettingsManager.hpp
+++ b/include/Core/SettingsManager.hpp
@@ -25,7 +25,7 @@
 #include <string>
 
 #define OLD_SETTINGS_FILE "cp_editor_settings.ini"
-#define NEW_SETTINGS_FILE ".cp_editor_settings.ini"
+#define SETTINGS_FILE ".cp_editor_settings.ini"
 
 namespace Settings
 {

--- a/include/Core/SettingsManager.hpp
+++ b/include/Core/SettingsManager.hpp
@@ -24,9 +24,6 @@
 #include <QString>
 #include <string>
 
-#define OLD_SETTINGS_FILE "cp_editor_settings.ini"
-#define SETTINGS_FILE ".cp_editor_settings.ini"
-
 namespace Settings
 {
 

--- a/src/Core/SettingsManager.cpp
+++ b/src/Core/SettingsManager.cpp
@@ -41,13 +41,13 @@ SettingManager::SettingManager()
             if (QFile::remove(oldSettingsFile))
                 Core::Log::i("settingmanager/constructor", oldSettingsFile + " File deleted successfully.");
             else
-                Core::Log::i("settingmanager/constructor", oldSettingsFile + " File failed to delete.");
+                Core::Log::e("settingmanager/constructor", oldSettingsFile + " File failed to delete.");
         }
         else
         {
-            Core::Log::i("settingmanager/constructor", "Setting migration failed");
+            Core::Log::e("settingmanager/constructor", "Setting migration failed");
             mSettingsFile = oldSettingsFile;
-            Core::Log::i("settingmanager/constructor", "Reverted to old settings file");
+            Core::Log::w("settingmanager/constructor", "Reverted to old settings file");
         }
     }
     else

--- a/src/Core/SettingsManager.cpp
+++ b/src/Core/SettingsManager.cpp
@@ -48,7 +48,8 @@ SettingManager::SettingManager()
             Core::Log::i("settingmanager/constructor", oldSettingsFile + " File failed to delete.");
     }
 <<<<<<< HEAD
-    else {
+    else
+    {
         Core::Log::i("settingmanager/constructor", "Old Settings file doesnot exist.");
         Core::Log::i("settingmanager/constructor", "Continuing with New Settings file.");
     }

--- a/src/Core/SettingsManager.cpp
+++ b/src/Core/SettingsManager.cpp
@@ -47,10 +47,10 @@ SettingManager::SettingManager()
         else
             Core::Log::i("settingmanager/constructor", oldSettingsFile + " File failed to delete.");
     }
-
-    Core::Log::i("settingmanager/constructor", "Old Settings file doesnot exist.");
-    Core::Log::i("settingmanager/constructor", "Continuing with New Settings file.");
-    
+    else {
+        Core::Log::i("settingmanager/constructor", "Old Settings file doesnot exist.");
+        Core::Log::i("settingmanager/constructor", "Continuing with New Settings file.");
+    }
     mSettings = new QSettings(mSettingsFile, QSettings::IniFormat);
 
     if (getDefaultLanguage() == "Cpp")

--- a/src/Core/SettingsManager.cpp
+++ b/src/Core/SettingsManager.cpp
@@ -35,17 +35,21 @@ SettingManager::SettingManager()
         Core::Log::i("settingmanager/constructor", oldSettingsFile + " exists.");
 
         if (QFile::copy(oldSettingsFile, mSettingsFile))
+        {
             Core::Log::i("settingmanager/constructor", "Old Settings migrated to new Settings File");
+            
+            if (QFile::remove(oldSettingsFile))
+                Core::Log::i("settingmanager/constructor", oldSettingsFile + " File deleted successfully.");
+            else
+                Core::Log::i("settingmanager/constructor", oldSettingsFile + " File failed to delete.");
+        }
         else
         {
             Core::Log::i("settingmanager/constructor", "Setting migration failed");
             mSettingsFile = oldSettingsFile;
             Core::Log::i("settingmanager/constructor", "Reverted to old settings file");
         }
-        if (QFile::remove(oldSettingsFile))
-            Core::Log::i("settingmanager/constructor", oldSettingsFile + " File deleted successfully.");
-        else
-            Core::Log::i("settingmanager/constructor", oldSettingsFile + " File failed to delete.");
+        
     }
     else
     {

--- a/src/Core/SettingsManager.cpp
+++ b/src/Core/SettingsManager.cpp
@@ -39,7 +39,7 @@ SettingManager::SettingManager()
         else
         {
             Core::Log::i("settingmanager/constructor", "Setting migration failed");
-            mSettingsFile = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/" + SETTINGS_FILE;
+            mSettingsFile = oldSettingsFile;
             Core::Log::i("settingmanager/constructor", "Reverted to old settings file");
         }
         if (QFile::remove(oldSettingsFile))

--- a/src/Core/SettingsManager.cpp
+++ b/src/Core/SettingsManager.cpp
@@ -19,20 +19,27 @@
 #include "Core/EventLogger.hpp"
 #include "Core/MessageLogger.hpp"
 #include <QApplication>
+#include <QDir>
 #include <QStandardPaths>
 
 namespace Settings
 {
+
+const QString OLD_SETTINGS_FILE = "cp_editor_settings.ini";
+const QString SETTINGS_FILE = ".cp_editor_settings.ini";
+
 SettingManager::SettingManager()
 {
     Core::Log::i("settingmanager/constructor", "Invoked");
 
-    mSettingsFile = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/" + SETTINGS_FILE;
-    QString oldSettingsFile = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/" + OLD_SETTINGS_FILE;
+    mSettingsFile = QDir(QStandardPaths::writableLocation(QStandardPaths::HomeLocation)).filePath(SETTINGS_FILE);
+    QString oldSettingsFile =
+        QDir(QStandardPaths::writableLocation(QStandardPaths::HomeLocation)).filePath(OLD_SETTINGS_FILE);
 
-    if (QFile::exists(oldSettingsFile))
+    if (!QFile::exists(mSettingsFile) && QFile::exists(oldSettingsFile))
     {
-        Core::Log::i("settingmanager/constructor", oldSettingsFile + " exists.");
+        Core::Log::i("settingmanager/constructor",
+                     mSettingsFile + "doesn't exist, but " + oldSettingsFile + " exists.");
 
         if (QFile::copy(oldSettingsFile, mSettingsFile))
         {
@@ -52,8 +59,9 @@ SettingManager::SettingManager()
     }
     else
     {
-        Core::Log::i("settingmanager/constructor", "Old Settings file doesnot exist.");
-        Core::Log::i("settingmanager/constructor", "Continuing with New Settings file.");
+        Core::Log::i(
+            "settingmanager/constructor",
+            "The new settings file exists or the old settings file does not exist, use the new settings file.");
     }
     mSettings = new QSettings(mSettingsFile, QSettings::IniFormat);
 

--- a/src/Core/SettingsManager.cpp
+++ b/src/Core/SettingsManager.cpp
@@ -28,7 +28,7 @@ SettingManager::SettingManager()
     Core::Log::i("settingmanager/constructor", "Invoked");
 
     mSettingsFile = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/" + SETTINGS_FILE;
-    QString oldSettingsFile = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/" + SETTINGS_FILE;
+    QString oldSettingsFile = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/" + OLD_SETTINGS_FILE;
 
     if (QFile::exists(oldSettingsFile))
     {

--- a/src/Core/SettingsManager.cpp
+++ b/src/Core/SettingsManager.cpp
@@ -26,7 +26,7 @@ namespace Settings
 SettingManager::SettingManager()
 {
     Core::Log::i("settingmanager/constructor", "Invoked");
-    
+
     mSettingsFile = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/" + NEW_SETTINGS_FILE;
     QString oldSettingsFile = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/" + SETTINGS_FILE;
 
@@ -36,7 +36,7 @@ SettingManager::SettingManager()
             Core::Log::i("settingmanager/constructor", "Old Settings migrated to new Settings File");
         else
             Core::Log::i("settingmanager/constructor", "Setting migration failed");
-        
+
         if (QFile::remove(oldSettingsFile))
             Core::Log::i("settingmanager/constructor", oldSettingsFile + " File deleted successfully.");
         else

--- a/src/Core/SettingsManager.cpp
+++ b/src/Core/SettingsManager.cpp
@@ -27,7 +27,7 @@ SettingManager::SettingManager()
 {
     Core::Log::i("settingmanager/constructor", "Invoked");
 
-    mSettingsFile = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/" + NEW_SETTINGS_FILE;
+    mSettingsFile = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/" + SETTINGS_FILE;
     QString oldSettingsFile = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/" + SETTINGS_FILE;
 
     if (QFile::exists(oldSettingsFile))

--- a/src/Core/SettingsManager.cpp
+++ b/src/Core/SettingsManager.cpp
@@ -37,7 +37,7 @@ SettingManager::SettingManager()
         if (QFile::copy(oldSettingsFile, mSettingsFile))
         {
             Core::Log::i("settingmanager/constructor", "Old Settings migrated to new Settings File");
-            
+
             if (QFile::remove(oldSettingsFile))
                 Core::Log::i("settingmanager/constructor", oldSettingsFile + " File deleted successfully.");
             else
@@ -49,7 +49,6 @@ SettingManager::SettingManager()
             mSettingsFile = oldSettingsFile;
             Core::Log::i("settingmanager/constructor", "Reverted to old settings file");
         }
-        
     }
     else
     {

--- a/src/Core/SettingsManager.cpp
+++ b/src/Core/SettingsManager.cpp
@@ -25,11 +25,25 @@ namespace Settings
 {
 SettingManager::SettingManager()
 {
-    Core::Log::i("settingmanager/constructed", "Invoked");
-    mSettingsFile = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/" + SETTINGS_FILE;
-    mSettings = new QSettings(mSettingsFile, QSettings::IniFormat);
+    Core::Log::i("settingmanager/constructor", "Invoked");
+    
+    mSettingsFile = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/" + NEW_SETTINGS_FILE;
+    QString oldSettingsFile = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/" + SETTINGS_FILE;
 
-    // backwords compatibility
+    if (QFile::exists(oldSettingsFile))
+    {
+        if (QFile::copy(oldSettingsFile, mSettingsFile))
+            Core::Log::i("settingmanager/constructor", "Old Settings migrated to new Settings File");
+        else
+            Core::Log::i("settingmanager/constructor", "Setting migration failed");
+        
+        if (QFile::remove(oldSettingsFile))
+            Core::Log::i("settingmanager/constructor", oldSettingsFile + " File deleted successfully.");
+        else
+            Core::Log::i("settingmanager/constructor", oldSettingsFile + " File failed to delete.");
+    }
+
+    mSettings = new QSettings(mSettingsFile, QSettings::IniFormat);
 
     if (getDefaultLanguage() == "Cpp")
         setDefaultLanguage("C++");

--- a/src/Core/SettingsManager.cpp
+++ b/src/Core/SettingsManager.cpp
@@ -47,18 +47,11 @@ SettingManager::SettingManager()
         else
             Core::Log::i("settingmanager/constructor", oldSettingsFile + " File failed to delete.");
     }
-<<<<<<< HEAD
     else
     {
         Core::Log::i("settingmanager/constructor", "Old Settings file doesnot exist.");
         Core::Log::i("settingmanager/constructor", "Continuing with New Settings file.");
     }
-=======
-
-    Core::Log::i("settingmanager/constructor", "Old Settings file doesnot exist.");
-    Core::Log::i("settingmanager/constructor", "Continuing with New Settings file.");
-
->>>>>>> origin/dev
     mSettings = new QSettings(mSettingsFile, QSettings::IniFormat);
 
     if (getDefaultLanguage() == "Cpp")

--- a/src/Core/SettingsManager.cpp
+++ b/src/Core/SettingsManager.cpp
@@ -32,17 +32,25 @@ SettingManager::SettingManager()
 
     if (QFile::exists(oldSettingsFile))
     {
+        Core::Log::i("settingmanager/constructor", oldSettingsFile + " exists.");
+
         if (QFile::copy(oldSettingsFile, mSettingsFile))
             Core::Log::i("settingmanager/constructor", "Old Settings migrated to new Settings File");
         else
+        {
             Core::Log::i("settingmanager/constructor", "Setting migration failed");
-
+            mSettingsFile = QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + "/" + SETTINGS_FILE;
+            Core::Log::i("settingmanager/constructor", "Reverted to old settings file");
+        }
         if (QFile::remove(oldSettingsFile))
             Core::Log::i("settingmanager/constructor", oldSettingsFile + " File deleted successfully.");
         else
             Core::Log::i("settingmanager/constructor", oldSettingsFile + " File failed to delete.");
     }
 
+    Core::Log::i("settingmanager/constructor", "Old Settings file doesnot exist.");
+    Core::Log::i("settingmanager/constructor", "Continuing with New Settings file.");
+    
     mSettings = new QSettings(mSettingsFile, QSettings::IniFormat);
 
     if (getDefaultLanguage() == "Cpp")


### PR DESCRIPTION
Add a dot at the front of the name of the config file. Fixes #163.
If `cp_editor_settings.ini` is found on the home directory,
the contents are simply copied to `.cp_editor_settings.ini`,
and the old file is deleted.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Tested on which OS(s)? Tested on light/dark system theme? -->

## Screenshots (if appropriate)

## Type of changes
<!--- What type of changes does your code introduce? Put an `x` in the box that applies: -->
- [ ] Bug fix (changes which fix an issue)
- [x] New feature (changes which add functionality)
- [ ] Documentation (changes which modify the documentation only)
- [ ] Style change (changes which do not affect the meaning of the code: code formatting, etc.)
- [ ] Refactor (changes which affect the meaning of the code but neither fix a bug nor add a feature)
- [ ] Performance improve (changes which improve performance)
- [ ] Test (changes which add tests)
- [ ] Build (Changes that affect the build system or external dependencies)
- [ ] CI (changes to CI configuration files and scripts)
- [ ] Chore (changes which do not belong to any type above)
- [ ] Revert (revert previous changes)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/coder3101/cp-editor/blob/master/CONTRIBUTING.md) document.
- [x] I have tested these changes locally, and this fixes the bug/the new feature behaves as the expectation.
- [x] I have used clang-format-9 and `.clang-format` file in the root directory to format my codes.
- [x] The settings file in the old version can be used in the new version after this change.
- [ ] These changes only fix a single bug/introduces a single feature. (Otherwise, open multiple Pull Requests instead, unless these bugs/features are closely related.)
- [ ] The commit messages are clear and detailed. (Otherwise, use `git reset` and commit again, or use `git rebase -i` and `git commit --amend` to modify the commit messages.)
- [x] These changes don't remove an existing feature. (Otherwise, add an option to disable this feature instead, unless it's necessary to remove this feature.)
